### PR TITLE
Added top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+#  Copyright (C) 2016 Johan Thelin <e8johan@gmail.com>
+#  Licensed under GPLv2, see file LICENSE in this source tree.
+
+PROJECT (contejner-top)
+
+CMAKE_MINIMUM_REQUIRED (VERSION 3.4)
+
+ADD_SUBDIRECTORY (service)
+ADD_SUBDIRECTORY (client)


### PR DESCRIPTION
Added a top-level CMakeLists.txt to make it possible to build the client and the server using a single make command.
